### PR TITLE
Simple Out-Of-Place Patch with SIMD-accelerated copy / C++ function overloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CC = gcc
-CFLAGS = -O3 -march=native -std=c11 -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
+STD=c11  # Changing to C99 requires POSIX-memalign.
+CFLAGS = -O3 -march=native -std=$(STD) -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
 
 all:
 	$(CC) fht.c -c $(CFLAGS)
-	$(CC) test_float.c fht.o -o test_float $(CFLAGS)
+	$(CC) test_float.c fht.o -o test_float $(CFLAGS) || echo "failed float"
 	$(CC) test_double.c fht.o -o test_double $(CFLAGS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 CC = gcc
-STD=c11  # Changing to C99 requires POSIX-memalign.
-CFLAGS = -O3 -march=native -std=$(STD) -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS = -O3 -march=native -std=c99 -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
 
 all:
 	$(CC) fht.c -c $(CFLAGS)
-	$(CC) test_float.c fht.o -o test_float $(CFLAGS) || echo "failed float"
-	$(CC) test_double.c fht.o -o test_double $(CFLAGS)
+	$(CC) fast_copy.c -c $(CFLAGS)
+	$(CC) test_float.c fast_copy.o fht.o -o test_float $(CFLAGS)
+	$(CC) test_double.c fast_copy.o fht.o -o test_double $(CFLAGS)
 
 clean:
-	rm -f fht.o test_float test_double
+	rm -f fht.o test_float test_double fast_copy.o

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,13 @@ CFLAGS = -O3 -march=native -std=c99 -pedantic -Wall -Wextra -Wshadow -Wpointer-a
 
 all: test_float test_double fast_copy.o fht.o
 
-fht.o: fht.c
-	$(CC) fht.c -c $(CFLAGS)
+OBJ := fast_copy.o fht.o
 
-fast_copy.o: fast_copy.c
-	$(CC) fast_copy.c -c $(CFLAGS)
+%.o: %.c
+	$(CC) $< -o $@ -c $(CFLAGS)
 
-test_float: test_float.c fast_copy.o fht.o
-	$(CC) test_float.c fast_copy.o fht.o -o test_float $(CFLAGS)
-
-test_double: test_double.c fast_copy.o fht.o
-	$(CC) test_double.c fast_copy.o fht.o -o test_double $(CFLAGS)
+test_%: test_%.c $(OBJ)
+	$(CC) $< $(OBJ) -o $@ $(CFLAGS)
 
 clean:
-	rm -f fht.o test_float test_double fast_copy.o
+	rm -f test_float test_double $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 CC = gcc
 CFLAGS = -O3 -march=native -std=c99 -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
 
-all:
+all: test_float test_double fast_copy.o fht.o
+
+fht.o: fht.c
 	$(CC) fht.c -c $(CFLAGS)
+
+fast_copy.o: fast_copy.c
 	$(CC) fast_copy.c -c $(CFLAGS)
+
+test_float: test_float.c fast_copy.o fht.o
 	$(CC) test_float.c fast_copy.o fht.o -o test_float $(CFLAGS)
+
+test_double: test_double.c fast_copy.o fht.o
 	$(CC) test_double.c fast_copy.o fht.o -o test_double $(CFLAGS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O3 -march=native -std=c99 -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS = -O3 -march=native -std=c11 -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
 
 all:
 	$(CC) fht.c -c $(CFLAGS)

--- a/fast_copy.c
+++ b/fast_copy.c
@@ -7,46 +7,44 @@
 
 // These functions all assume that the size of memory being copied is a power of 2.
 
-#define DEFAULT_TO_MEMCPY_TEST(mask) ((n & mask) || n >= (FAST_COPY_MEMCPY_THRESHOLD))
-
 #if _FEATURE_AVX512F
 // If n is less than 64, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
-void fast_copy(void *out, void *in, size_t n) {
-    if(DEFAULT_TO_MEMCPY_TEST(53u)) {
-        memcpy(out, in, n);
-        return;
+void *fast_copy(void *out, void *in, size_t n) {
+    if(n >= FAST_COPY_MEMCPY_THRESHOLD) {
+        return memcpy(out, in, n);
     }
     n >>= 6;
     for(__m512 *ov = (__m512 *)out, *iv = (__m512 *)in; n--;) {
         _mm512_storeu_ps((float *)(ov++), _mm512_loadu_ps((float *)(iv++)));
     }
+    return out;
 }
 #elif __AVX2__
 // If n is less than 32, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
-void fast_copy(void *out, void *in, size_t n) {
-    if(DEFAULT_TO_MEMCPY_TEST(31u)) {
-        memcpy(out, in, n);
-        return;
+void *fast_copy(void *out, void *in, size_t n) {
+    if(n >= FAST_COPY_MEMCPY_THRESHOLD) {
+        return memcpy(out, in, n);
     }
     n >>= 5;
     for(__m256 *ov = (__m256 *)out, *iv = (__m256 *)in; n--;) {
         _mm256_storeu_ps((float *)(ov++), _mm256_loadu_ps((float *)(iv++)));
     }
+    return out;
 }
 #elif __SSE2__
 // If n is less than 16, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
-void fast_copy(void *out, void *in, size_t n) {
-    if(DEFAULT_TO_MEMCPY_TEST(15u)) {
-        memcpy(out, in, n);
-        return;
+void *fast_copy(void *out, void *in, size_t n) {
+    if(n >= FAST_COPY_MEMCPY_THRESHOLD) {
+        return memcpy(out, in, n);
     }
     n >>= 4;
     for(__m128 *ov = (__m128 *)out, *iv = (__m128 *)in; n--;) {
         _mm_storeu_ps((float *)(ov++), _mm_loadu_ps((float *)(iv++)));
     }
+    return out;
 }
 #else
-void fast_copy(void *out, void *in, size_t n) {
-    memcpy(out, in, n);
+void *fast_copy(void *out, void *in, size_t n) {
+    return memcpy(out, in, n);
 }
 #endif

--- a/fast_copy.c
+++ b/fast_copy.c
@@ -1,0 +1,61 @@
+#include "fast_copy.h"
+#include <string.h>
+#include <stdlib.h>
+#if (defined(__x86_64__) || defined(__i386__))
+#  include <x86intrin.h>
+#endif
+
+#if __AVX2__
+// If unaligned or n is less than 32, defaults to memcpy.
+void fast_copy(void *out, void *in, size_t n) {
+    if(n < 32 || ((long long)out & 31) || ((long long)in & 31)) {
+        memcpy(out, in, n);
+        return;
+    }
+    __m256 *ov = (__m256 *)out;
+    __m256 *iv = (__m256 *)in;
+    size_t f = (n >> 5) >> 3, leftover = (n >> 5) & 0x7u;
+    n = 0;
+    switch(leftover) {
+        case 0: do {
+                ov[n] = iv[n]; ++n;
+        case 7: ov[n] = iv[n]; ++n;
+        case 6: ov[n] = iv[n]; ++n;
+        case 5: ov[n] = iv[n]; ++n;
+        case 4: ov[n] = iv[n]; ++n;
+        case 3: ov[n] = iv[n]; ++n;
+        case 2: ov[n] = iv[n]; ++n;
+        case 1: ov[n] = iv[n]; ++n;
+                   } while(f--);
+    }
+}
+#elif __SSE2__
+// If unaligned or n is less than 16, defaults to memcpy
+// Assumes alignment and that n is a power of 2 >= 16
+void fast_copy(void *out, void *in, size_t n) {
+    if(n < 16 || ((long long)out & 15) || ((long long)in & 15)) {
+        memcpy(out, in, n);
+        return;
+    }
+    __m128 *ov = (__m128 *)out;
+    __m128 *iv = (__m128 *)in;
+    size_t f = (n >> 4) >> 3, leftover = (n >> 4) & 0x7u;
+    n = 0;
+    switch(leftover) {
+        case 0: do {
+                ov[n] = iv[n]; ++n;
+        case 7: ov[n] = iv[n]; ++n;
+        case 6: ov[n] = iv[n]; ++n;
+        case 5: ov[n] = iv[n]; ++n;
+        case 4: ov[n] = iv[n]; ++n;
+        case 3: ov[n] = iv[n]; ++n;
+        case 2: ov[n] = iv[n]; ++n;
+        case 1: ov[n] = iv[n]; ++n;
+                   } while(f--);
+    }
+}
+#else
+void fast_copy(void *out, void *in, size_t n) {
+        memcpy(out, in, n);
+}
+#endif

--- a/fast_copy.c
+++ b/fast_copy.c
@@ -7,10 +7,12 @@
 
 // These functions all assume that the size of memory being copied is a power of 2.
 
+#define DEFAULT_TO_MEMCPY_TEST(mask) ((n & mask) || n >= (FAST_COPY_MEMCPY_THRESHOLD))
+
 #if _FEATURE_AVX512F
 // If n is less than 64, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
 void fast_copy(void *out, void *in, size_t n) {
-    if(n & 63) {
+    if(DEFAULT_TO_MEMCPY_TEST(53u)) {
         memcpy(out, in, n);
         return;
     }
@@ -22,7 +24,7 @@ void fast_copy(void *out, void *in, size_t n) {
 #elif __AVX2__
 // If n is less than 32, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
 void fast_copy(void *out, void *in, size_t n) {
-    if(n & 32) {
+    if(DEFAULT_TO_MEMCPY_TEST(31u)) {
         memcpy(out, in, n);
         return;
     }
@@ -34,7 +36,7 @@ void fast_copy(void *out, void *in, size_t n) {
 #elif __SSE2__
 // If n is less than 16, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
 void fast_copy(void *out, void *in, size_t n) {
-    if(n & 15u) {
+    if(DEFAULT_TO_MEMCPY_TEST(15u)) {
         memcpy(out, in, n);
         return;
     }
@@ -45,6 +47,6 @@ void fast_copy(void *out, void *in, size_t n) {
 }
 #else
 void fast_copy(void *out, void *in, size_t n) {
-        memcpy(out, in, n);
+    memcpy(out, in, n);
 }
 #endif

--- a/fast_copy.c
+++ b/fast_copy.c
@@ -5,53 +5,42 @@
 #  include <x86intrin.h>
 #endif
 
-#if __AVX2__
-// If unaligned or n is less than 32, defaults to memcpy.
+// These functions all assume that the size of memory being copied is a power of 2.
+
+#if _FEATURE_AVX512F
+// If n is less than 64, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
 void fast_copy(void *out, void *in, size_t n) {
-    if(n < 32 || ((long long)out & 31) || ((long long)in & 31)) {
+    if(n & 63) {
         memcpy(out, in, n);
         return;
     }
-    __m256 *ov = (__m256 *)out;
-    __m256 *iv = (__m256 *)in;
-    size_t f = (n >> 5) >> 3, leftover = (n >> 5) & 0x7u;
-    n = 0;
-    switch(leftover) {
-        case 0: do {
-                ov[n] = iv[n]; ++n;
-        case 7: ov[n] = iv[n]; ++n;
-        case 6: ov[n] = iv[n]; ++n;
-        case 5: ov[n] = iv[n]; ++n;
-        case 4: ov[n] = iv[n]; ++n;
-        case 3: ov[n] = iv[n]; ++n;
-        case 2: ov[n] = iv[n]; ++n;
-        case 1: ov[n] = iv[n]; ++n;
-                   } while(f--);
+    n >>= 6;
+    for(__m512 *ov = (__m512 *)out, *iv = (__m512 *)in; n--;) {
+        _mm512_storeu_ps((float *)(ov++), _mm512_loadu_ps((float *)(iv++)));
+    }
+}
+#elif __AVX2__
+// If n is less than 32, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
+void fast_copy(void *out, void *in, size_t n) {
+    if(n & 32) {
+        memcpy(out, in, n);
+        return;
+    }
+    n >>= 5;
+    for(__m256 *ov = (__m256 *)out, *iv = (__m256 *)in; n--;) {
+        _mm256_storeu_ps((float *)(ov++), _mm256_loadu_ps((float *)(iv++)));
     }
 }
 #elif __SSE2__
-// If unaligned or n is less than 16, defaults to memcpy
-// Assumes alignment and that n is a power of 2 >= 16
+// If n is less than 16, defaults to memcpy. Otherwise, being a power of 2, we can just use unaligned stores and loads.
 void fast_copy(void *out, void *in, size_t n) {
-    if(n < 16 || ((long long)out & 15) || ((long long)in & 15)) {
+    if(n & 15u) {
         memcpy(out, in, n);
         return;
     }
-    __m128 *ov = (__m128 *)out;
-    __m128 *iv = (__m128 *)in;
-    size_t f = (n >> 4) >> 3, leftover = (n >> 4) & 0x7u;
-    n = 0;
-    switch(leftover) {
-        case 0: do {
-                ov[n] = iv[n]; ++n;
-        case 7: ov[n] = iv[n]; ++n;
-        case 6: ov[n] = iv[n]; ++n;
-        case 5: ov[n] = iv[n]; ++n;
-        case 4: ov[n] = iv[n]; ++n;
-        case 3: ov[n] = iv[n]; ++n;
-        case 2: ov[n] = iv[n]; ++n;
-        case 1: ov[n] = iv[n]; ++n;
-                   } while(f--);
+    n >>= 4;
+    for(__m128 *ov = (__m128 *)out, *iv = (__m128 *)in; n--;) {
+        _mm_storeu_ps((float *)(ov++), _mm_loadu_ps((float *)(iv++)));
     }
 }
 #else

--- a/fast_copy.h
+++ b/fast_copy.h
@@ -2,6 +2,12 @@
 #define _FAST_COPY_H__
 
 #include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 void fast_copy(void *out, void *in, size_t m);
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif // _FAST_COPY_H__

--- a/fast_copy.h
+++ b/fast_copy.h
@@ -1,0 +1,7 @@
+#ifndef _FAST_COPY_H__
+#define _FAST_COPY_H__
+
+#include <stdlib.h>
+void fast_copy(void *out, void *in, size_t m);
+
+#endif // _FAST_COPY_H__

--- a/fast_copy.h
+++ b/fast_copy.h
@@ -9,7 +9,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void fast_copy(void *out, void *in, size_t m);
+void *fast_copy(void *out, void *in, size_t m);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/fast_copy.h
+++ b/fast_copy.h
@@ -1,7 +1,11 @@
 #ifndef _FAST_COPY_H__
 #define _FAST_COPY_H__
-
 #include <stdlib.h>
+
+#ifndef FAST_COPY_MEMCPY_THRESHOLD
+#  define FAST_COPY_MEMCPY_THRESHOLD (1ull << 23)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/fht.h
+++ b/fht.h
@@ -1,5 +1,7 @@
 #ifndef _FHT_H_
 #define _FHT_H_
+#include <string.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -7,9 +9,29 @@ extern "C" {
 
 int fht_float(float *buf, int log_n);
 int fht_double(double *buf, int log_n);
+int fht_float_oop(float *in, float *out, int log_n);
+int fht_double_oop(double *in, double *out, int log_n);
+
 
 #ifdef __cplusplus
+
+static inline int fht(float *buf, int log_n) {
+    return fht_float(buf, log_n);
 }
+
+static inline int fht(double *buf, int log_n) {
+    return fht_double(buf, log_n);
+}
+
+static inline int fht(float *buf, float *out, int log_n) {
+    return fht_float_oop(buf, out, log_n);
+}
+
+static inline int fht(double *buf, double *out, int log_n) {
+    return fht_double_oop(buf, out, log_n);
+}
+
+} // extern "C"
 #endif
 
 #endif

--- a/fht.h
+++ b/fht.h
@@ -15,6 +15,8 @@ int fht_double_oop(double *in, double *out, int log_n);
 
 #ifdef __cplusplus
 
+} // extern "C"
+
 static inline int fht(float *buf, int log_n) {
     return fht_float(buf, log_n);
 }
@@ -31,7 +33,6 @@ static inline int fht(double *buf, double *out, int log_n) {
     return fht_double_oop(buf, out, log_n);
 }
 
-} // extern "C"
 #endif
 
 #endif

--- a/fht_avx.c
+++ b/fht_avx.c
@@ -1,6 +1,6 @@
 #include "fht.h"
-inline void helper_float_1(float *buf);
-inline void helper_float_1(float *buf) {
+static inline void helper_float_1(float *buf);
+static inline void helper_float_1(float *buf) {
   for (int j = 0; j < 2; j += 2) {
     for (int k = 0; k < 1; ++k) {
       float u = buf[j + k];
@@ -10,8 +10,8 @@ inline void helper_float_1(float *buf) {
     }
   }
 }
-inline void helper_float_2(float *buf);
-inline void helper_float_2(float *buf) {
+static inline void helper_float_2(float *buf);
+static inline void helper_float_2(float *buf) {
   for (int j = 0; j < 4; j += 2) {
     for (int k = 0; k < 1; ++k) {
       float u = buf[j + k];
@@ -29,8 +29,8 @@ inline void helper_float_2(float *buf) {
     }
   }
 }
-inline void helper_float_3(float *buf);
-inline void helper_float_3(float *buf) {
+static inline void helper_float_3(float *buf);
+static inline void helper_float_3(float *buf) {
   for (int j = 0; j < 8; j += 8) {
     __asm__ volatile (
       "vmovups (%0), %%ymm0\n"
@@ -55,8 +55,8 @@ inline void helper_float_3(float *buf) {
     );
   }
 }
-inline void helper_float_4(float *buf);
-inline void helper_float_4(float *buf) {
+static inline void helper_float_4(float *buf);
+static inline void helper_float_4(float *buf) {
   for (int j = 0; j < 16; j += 16) {
     for (int k = 0; k < 8; k += 8) {
       __asm__ volatile (
@@ -103,8 +103,8 @@ inline void helper_float_4(float *buf) {
     }
   }
 }
-inline void helper_float_5(float *buf);
-inline void helper_float_5(float *buf) {
+static inline void helper_float_5(float *buf);
+static inline void helper_float_5(float *buf) {
   for (int j = 0; j < 32; j += 32) {
     for (int k = 0; k < 8; k += 8) {
       __asm__ volatile (
@@ -193,8 +193,8 @@ inline void helper_float_5(float *buf) {
     }
   }
 }
-inline void helper_float_6(float *buf);
-inline void helper_float_6(float *buf) {
+static inline void helper_float_6(float *buf);
+static inline void helper_float_6(float *buf) {
   for (int j = 0; j < 64; j += 64) {
     for (int k = 0; k < 8; k += 8) {
       __asm__ volatile (
@@ -784,8 +784,8 @@ void helper_float_8(float *buf);
 void helper_float_8(float *buf) {
   helper_float_8_recursive(buf, 8);
 }
-inline void helper_float_9(float *buf);
-inline void helper_float_9(float *buf) {
+static inline void helper_float_9(float *buf);
+static inline void helper_float_9(float *buf) {
   for (int j = 0; j < 512; j += 64) {
     for (int k = 0; k < 8; k += 8) {
       __asm__ volatile (
@@ -1509,8 +1509,8 @@ void helper_float_11(float *buf);
 void helper_float_11(float *buf) {
   helper_float_11_recursive(buf, 11);
 }
-inline void helper_float_12(float *buf);
-inline void helper_float_12(float *buf) {
+static inline void helper_float_12(float *buf);
+static inline void helper_float_12(float *buf) {
   for (int j = 0; j < 4096; j += 64) {
     for (int k = 0; k < 8; k += 8) {
       __asm__ volatile (
@@ -10204,8 +10204,8 @@ int fht_float(float *buf, int log_n) {
   }
   return 1;
 }
-inline void helper_double_1(double *buf);
-inline void helper_double_1(double *buf) {
+static inline void helper_double_1(double *buf);
+static inline void helper_double_1(double *buf) {
   for (int j = 0; j < 2; j += 2) {
     for (int k = 0; k < 1; ++k) {
       double u = buf[j + k];
@@ -10215,8 +10215,8 @@ inline void helper_double_1(double *buf) {
     }
   }
 }
-inline void helper_double_2(double *buf);
-inline void helper_double_2(double *buf) {
+static inline void helper_double_2(double *buf);
+static inline void helper_double_2(double *buf) {
   for (int j = 0; j < 4; j += 4) {
     __asm__ volatile (
       "vmovupd (%0), %%ymm0\n"
@@ -10235,8 +10235,8 @@ inline void helper_double_2(double *buf) {
     );
   }
 }
-inline void helper_double_3(double *buf);
-inline void helper_double_3(double *buf) {
+static inline void helper_double_3(double *buf);
+static inline void helper_double_3(double *buf) {
   for (int j = 0; j < 8; j += 8) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -10344,8 +10344,8 @@ void helper_double_4(double *buf);
 void helper_double_4(double *buf) {
   helper_double_4_recursive(buf, 4);
 }
-inline void helper_double_5(double *buf);
-inline void helper_double_5(double *buf) {
+static inline void helper_double_5(double *buf);
+static inline void helper_double_5(double *buf) {
   for (int j = 0; j < 32; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -10474,8 +10474,8 @@ inline void helper_double_5(double *buf) {
     }
   }
 }
-inline void helper_double_6(double *buf);
-inline void helper_double_6(double *buf) {
+static inline void helper_double_6(double *buf);
+static inline void helper_double_6(double *buf) {
   for (int j = 0; j < 64; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -10617,8 +10617,8 @@ inline void helper_double_6(double *buf) {
     }
   }
 }
-inline void helper_double_7(double *buf);
-inline void helper_double_7(double *buf) {
+static inline void helper_double_7(double *buf);
+static inline void helper_double_7(double *buf) {
   for (int j = 0; j < 128; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -10770,8 +10770,8 @@ inline void helper_double_7(double *buf) {
     }
   }
 }
-inline void helper_double_8(double *buf);
-inline void helper_double_8(double *buf) {
+static inline void helper_double_8(double *buf);
+static inline void helper_double_8(double *buf) {
   for (int j = 0; j < 256; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -10947,8 +10947,8 @@ inline void helper_double_8(double *buf) {
     }
   }
 }
-inline void helper_double_9(double *buf);
-inline void helper_double_9(double *buf) {
+static inline void helper_double_9(double *buf);
+static inline void helper_double_9(double *buf) {
   for (int j = 0; j < 512; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -11137,8 +11137,8 @@ inline void helper_double_9(double *buf) {
     }
   }
 }
-inline void helper_double_10(double *buf);
-inline void helper_double_10(double *buf) {
+static inline void helper_double_10(double *buf);
+static inline void helper_double_10(double *buf) {
   for (int j = 0; j < 1024; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -11337,8 +11337,8 @@ inline void helper_double_10(double *buf) {
     }
   }
 }
-inline void helper_double_11(double *buf);
-inline void helper_double_11(double *buf) {
+static inline void helper_double_11(double *buf);
+static inline void helper_double_11(double *buf) {
   for (int j = 0; j < 2048; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (

--- a/fht_header_only.h
+++ b/fht_header_only.h
@@ -2,7 +2,28 @@
 #define _FHT_H_
 
 int fht_float(float *buf, int log_n);
-int fht_double(float *buf, int log_n);
+int fht_double(double *buf, int log_n);
+int fht_float_oop(float *in, float *out, int log_n);
+int fht_double_oop(double *in, double *out, int log_n);
+
+
+#ifdef __cplusplus
+static inline int fht(float *buf, int log_n) {
+    return fht_float(buf, log_n);
+}
+
+static inline int fht(double *buf, int log_n) {
+    return fht_double(buf, log_n);
+}
+
+static inline int fht(float *buf, float *out, int log_n) {
+    return fht_float_oop(buf, out, log_n);
+}
+
+static inline int fht(double *buf, double *out, int log_n) {
+    return fht_double_oop(buf, out, log_n);
+}
+#endif // #ifdef __cplusplus
 
 #include "fht_impl.h"
 

--- a/fht_impl.h
+++ b/fht_impl.h
@@ -5,3 +5,31 @@
 #include "fht_sse.c"
 #define VECTOR_WIDTH (16u)
 #endif
+
+#if !_ISOC11_SOURCE
+#  if !_POSIX_C_SOURCE >= 200112L && !_XOPEN_SOURCE >= 600
+#    error("Need either ISOC11 or POSIX support for aligned allocation.")
+#  endif
+void *aligned_alloc(size_t size, size_t alignment) {
+    void *ret;
+    if(posix_memalign(&ret, size, alignment)) return 0;
+    return ret;
+}
+#endif
+
+int fht_float_oop(float *in, float *out, int log_n) {
+    if(out == 0) {
+        if((out = aligned_alloc(sizeof(float) << log_n, VECTOR_WIDTH)) == 0) return -2;
+        memcpy(out, in, sizeof(float) << log_n);
+    }
+    return fht_float(in, out, log_n);
+}
+
+int fht_double_oop(double *in, double *out, int log_n) {
+    if(out == 0) {
+        if((out = aligned_alloc(sizeof(double) << log_n, VECTOR_WIDTH)) == 0) return -2;
+        memcpy(out, in, sizeof(double) << log_n);
+    }
+    return fht_double(in, out, log_n);
+}
+

--- a/fht_impl.h
+++ b/fht_impl.h
@@ -1,3 +1,4 @@
+#include "fast_copy.h"
 #ifdef __AVX__
 #include "fht_avx.c"
 #define VECTOR_WIDTH (32u)
@@ -6,30 +7,12 @@
 #define VECTOR_WIDTH (16u)
 #endif
 
-#if !_ISOC11_SOURCE
-#  if !_POSIX_C_SOURCE >= 200112L && !_XOPEN_SOURCE >= 600
-#    error("Need either ISOC11 or POSIX support for aligned allocation.")
-#  endif
-void *aligned_alloc(size_t size, size_t alignment) {
-    void *ret;
-    if(posix_memalign(&ret, size, alignment)) return 0;
-    return ret;
-}
-#endif
-
 int fht_float_oop(float *in, float *out, int log_n) {
-    if(out == 0) {
-        if((out = aligned_alloc(sizeof(float) << log_n, VECTOR_WIDTH)) == 0) return -2;
-        memcpy(out, in, sizeof(float) << log_n);
-    }
+    fast_copy(out, in, sizeof(float) << log_n);
     return fht_float(out, log_n);
 }
 
 int fht_double_oop(double *in, double *out, int log_n) {
-    if(out == 0) {
-        if((out = aligned_alloc(sizeof(double) << log_n, VECTOR_WIDTH)) == 0) return -2;
-        memcpy(out, in, sizeof(double) << log_n);
-    }
+    fast_copy(out, in, sizeof(double) << log_n);
     return fht_double(out, log_n);
 }
-

--- a/fht_impl.h
+++ b/fht_impl.h
@@ -1,5 +1,7 @@
 #ifdef __AVX__
 #include "fht_avx.c"
+#define VECTOR_WIDTH (32u)
 #else
 #include "fht_sse.c"
+#define VECTOR_WIDTH (16u)
 #endif

--- a/fht_impl.h
+++ b/fht_impl.h
@@ -1,4 +1,12 @@
+#ifndef _FHT_IMPL_H__
+#define _FHT_IMPL_H__
+
 #include "fast_copy.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef __AVX__
 #include "fht_avx.c"
 #define VECTOR_WIDTH (32u)
@@ -16,3 +24,9 @@ int fht_double_oop(double *in, double *out, int log_n) {
     fast_copy(out, in, sizeof(double) << log_n);
     return fht_double(out, log_n);
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // ifndef _FHT_IMPL_H__

--- a/fht_impl.h
+++ b/fht_impl.h
@@ -22,7 +22,7 @@ int fht_float_oop(float *in, float *out, int log_n) {
         if((out = aligned_alloc(sizeof(float) << log_n, VECTOR_WIDTH)) == 0) return -2;
         memcpy(out, in, sizeof(float) << log_n);
     }
-    return fht_float(in, out, log_n);
+    return fht_float(out, log_n);
 }
 
 int fht_double_oop(double *in, double *out, int log_n) {
@@ -30,6 +30,6 @@ int fht_double_oop(double *in, double *out, int log_n) {
         if((out = aligned_alloc(sizeof(double) << log_n, VECTOR_WIDTH)) == 0) return -2;
         memcpy(out, in, sizeof(double) << log_n);
     }
-    return fht_double(in, out, log_n);
+    return fht_double(out, log_n);
 }
 

--- a/fht_sse.c
+++ b/fht_sse.c
@@ -1,6 +1,6 @@
 #include "fht.h"
-inline void helper_float_1(float *buf);
-inline void helper_float_1(float *buf) {
+static inline void helper_float_1(float *buf);
+static inline void helper_float_1(float *buf) {
   for (int j = 0; j < 2; j += 2) {
     for (int k = 0; k < 1; ++k) {
       float u = buf[j + k];
@@ -10,8 +10,8 @@ inline void helper_float_1(float *buf) {
     }
   }
 }
-inline void helper_float_2(float *buf);
-inline void helper_float_2(float *buf) {
+static inline void helper_float_2(float *buf);
+static inline void helper_float_2(float *buf) {
   for (int j = 0; j < 4; j += 4) {
     __asm__ volatile (
       "movups (%0), %%xmm0\n"
@@ -37,8 +37,8 @@ inline void helper_float_2(float *buf) {
     );
   }
 }
-inline void helper_float_3(float *buf);
-inline void helper_float_3(float *buf) {
+static inline void helper_float_3(float *buf);
+static inline void helper_float_3(float *buf) {
   for (int j = 0; j < 8; j += 8) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -89,8 +89,8 @@ inline void helper_float_3(float *buf) {
     }
   }
 }
-inline void helper_float_4(float *buf);
-inline void helper_float_4(float *buf) {
+static inline void helper_float_4(float *buf);
+static inline void helper_float_4(float *buf) {
   for (int j = 0; j < 16; j += 16) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -191,8 +191,8 @@ inline void helper_float_4(float *buf) {
     }
   }
 }
-inline void helper_float_5(float *buf);
-inline void helper_float_5(float *buf) {
+static inline void helper_float_5(float *buf);
+static inline void helper_float_5(float *buf) {
   for (int j = 0; j < 32; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -401,8 +401,8 @@ inline void helper_float_5(float *buf) {
     }
   }
 }
-inline void helper_float_6(float *buf);
-inline void helper_float_6(float *buf) {
+static inline void helper_float_6(float *buf);
+static inline void helper_float_6(float *buf) {
   for (int j = 0; j < 64; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -874,8 +874,8 @@ void helper_float_7(float *buf);
 void helper_float_7(float *buf) {
   helper_float_7_recursive(buf, 7);
 }
-inline void helper_float_8(float *buf);
-inline void helper_float_8(float *buf) {
+static inline void helper_float_8(float *buf);
+static inline void helper_float_8(float *buf) {
   for (int j = 0; j < 256; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -1155,8 +1155,8 @@ inline void helper_float_8(float *buf) {
     }
   }
 }
-inline void helper_float_9(float *buf);
-inline void helper_float_9(float *buf) {
+static inline void helper_float_9(float *buf);
+static inline void helper_float_9(float *buf) {
   for (int j = 0; j < 512; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -1451,8 +1451,8 @@ inline void helper_float_9(float *buf) {
     }
   }
 }
-inline void helper_float_10(float *buf);
-inline void helper_float_10(float *buf) {
+static inline void helper_float_10(float *buf);
+static inline void helper_float_10(float *buf) {
   for (int j = 0; j < 1024; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -1763,8 +1763,8 @@ inline void helper_float_10(float *buf) {
     }
   }
 }
-inline void helper_float_11(float *buf);
-inline void helper_float_11(float *buf) {
+static inline void helper_float_11(float *buf);
+static inline void helper_float_11(float *buf) {
   for (int j = 0; j < 2048; j += 32) {
     for (int k = 0; k < 4; k += 4) {
       __asm__ volatile (
@@ -13951,8 +13951,8 @@ int fht_float(float *buf, int log_n) {
   }
   return 1;
 }
-inline void helper_double_1(double *buf);
-inline void helper_double_1(double *buf) {
+static inline void helper_double_1(double *buf);
+static inline void helper_double_1(double *buf) {
   for (int j = 0; j < 2; j += 2) {
     __asm__ volatile (
       "movupd (%0), %%xmm0\n"
@@ -14069,8 +14069,8 @@ void helper_double_3(double *buf);
 void helper_double_3(double *buf) {
   helper_double_3_recursive(buf, 3);
 }
-inline void helper_double_4(double *buf);
-inline void helper_double_4(double *buf) {
+static inline void helper_double_4(double *buf);
+static inline void helper_double_4(double *buf) {
   for (int j = 0; j < 16; j += 16) {
     for (int k = 0; k < 2; k += 2) {
       __asm__ volatile (
@@ -14310,8 +14310,8 @@ void helper_double_5(double *buf);
 void helper_double_5(double *buf) {
   helper_double_5_recursive(buf, 5);
 }
-inline void helper_double_6(double *buf);
-inline void helper_double_6(double *buf) {
+static inline void helper_double_6(double *buf);
+static inline void helper_double_6(double *buf) {
   for (int j = 0; j < 64; j += 16) {
     for (int k = 0; k < 2; k += 2) {
       __asm__ volatile (
@@ -14463,8 +14463,8 @@ inline void helper_double_6(double *buf) {
     }
   }
 }
-inline void helper_double_7(double *buf);
-inline void helper_double_7(double *buf) {
+static inline void helper_double_7(double *buf);
+static inline void helper_double_7(double *buf) {
   for (int j = 0; j < 128; j += 16) {
     for (int k = 0; k < 2; k += 2) {
       __asm__ volatile (
@@ -15962,8 +15962,8 @@ void helper_double_12(double *buf);
 void helper_double_12(double *buf) {
   helper_double_12_recursive(buf, 12);
 }
-inline void helper_double_13(double *buf);
-inline void helper_double_13(double *buf) {
+static inline void helper_double_13(double *buf);
+static inline void helper_double_13(double *buf) {
   for (int j = 0; j < 8192; j += 16) {
     for (int k = 0; k < 2; k += 2) {
       __asm__ volatile (

--- a/gen.py
+++ b/gen.py
@@ -387,7 +387,7 @@ def double_sse_composite_step(buf_name, log_n, from_it, to_it, ident=''):
 
 
 def plain_unmerged(type_name, log_n):
-    signature = "inline void helper_%s_%d(%s *buf)" % (type_name, log_n,
+    signature = "static inline void helper_%s_%d(%s *buf)" % (type_name, log_n,
                                                        type_name)
     res = '%s;\n' % signature
     res += '%s {\n' % signature
@@ -402,7 +402,7 @@ def greedy_merged(type_name, log_n, composite_step):
         composite_step('buf', log_n, 0, 0)
     except Exception:
         raise Exception('log_n is too small: %d' % log_n)
-    signature = 'inline void helper_%s_%d(%s *buf)' % (type_name, log_n,
+    signature = 'static inline void helper_%s_%d(%s *buf)' % (type_name, log_n,
                                                        type_name)
     res = '%s;\n' % signature
     res += '%s {\n' % signature

--- a/test_double.c
+++ b/test_double.c
@@ -33,7 +33,7 @@ int main(void) {
         double *a = (double*)start;
         double *aux = (double*)malloc(sizeof(double) * n);
         for (int i = 0; i < n; ++i) {
-            a[i] = 1.0 - 2.0 * (rand() % 2);
+            a[i] = 1.0 - 2.0 * (rand() & 1);
             aux[i] = a[i];
         }
         fht_double(a, log_n);

--- a/test_float.c
+++ b/test_float.c
@@ -33,7 +33,7 @@ int main(void) {
         float *a = (float*)start;
         float *aux = (float*)malloc(sizeof(double) * n);
         for (int i = 0; i < n; ++i) {
-            a[i] = 1.0 - 2.0 * (rand() % 2);
+            a[i] = 1.0 - 2.0 * (rand() & 1);
             aux[i] = a[i];
         }
         fht_float(a, log_n);


### PR DESCRIPTION
I added these features for myself and thought they could potentially be useful for others.

For C and C++, adds SIMD-accelerated memory copying for out-of-place operations. Fast copying does assume that the data has been aligned. (If it isn't, it falls back to memcpy, so it's still safe.)

It's only cosmetic, but it also adds fht(args...) overloads for in-place and out-of-place FHT of single and double precision types for C++.

This isn't as fast as possible due to multiple passes through the data, but it seems to be a decent interim solution.