### PR TITLE
Throw an error in setup.py if Python version is not 2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ except ImportError:
     sys.stderr.write('NumPy not found!\n')
     raise
 
+if sys.version_info[0] != 2:
+    raise RuntimeError("Error: FFHT currently only supports Python 2.")
+
 module = Extension('_ffht',
                    sources=['_ffht.c', 'fht.c'],
                    extra_compile_args=['-march=native', '-O3', '-Wall', '-Wextra', '-pedantic',


### PR DESCRIPTION
This should prevent further users from running into the rather opaque error message in [this issue](https://github.com/FALCONN-LIB/FFHT/issues/21).